### PR TITLE
Avoid passing empty headers during upgrade

### DIFF
--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -136,10 +136,12 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Only pass those headers to the upgrader.
 	upgradeHeader := http.Header{}
-	upgradeHeader.Set("Sec-WebSocket-Protocol",
-		resp.Header.Get(http.CanonicalHeaderKey("Sec-WebSocket-Protocol")))
-	upgradeHeader.Set("Set-Cookie",
-		resp.Header.Get(http.CanonicalHeaderKey("Set-Cookie")))
+	if hdr := resp.Header.Get("Sec-WebSocket-Protocol"); hdr != "" {
+		upgradeHeader.Set("Sec-WebSocket-Protocol", hdr)
+	}
+	if hdr := resp.Header.Get("Set-Cookie"); hdr != "" {
+		upgradeHeader.Set("Set-Cookie", hdr)
+	}
 
 	// Now upgrade the existing incoming request to a WebSocket connection.
 	// Also pass the header that we gathered from the Dial handshake.

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -136,8 +136,8 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Only pass those headers to the upgrader.
 	upgradeHeader := http.Header{}
-	if hdr := resp.Header.Get("Sec-WebSocket-Protocol"); hdr != "" {
-		upgradeHeader.Set("Sec-WebSocket-Protocol", hdr)
+	if hdr := resp.Header.Get("Sec-Websocket-Protocol"); hdr != "" {
+		upgradeHeader.Set("Sec-Websocket-Protocol", hdr)
 	}
 	if hdr := resp.Header.Get("Set-Cookie"); hdr != "" {
 		upgradeHeader.Set("Set-Cookie", hdr)


### PR DESCRIPTION
This fixes the proxy for Safari which fails with a cryptic `Invalid UTF-8 sequence in header value ` error when the upgrade request contains a header with an empty Value e.g. `Set-Cookie: `

I also removed the `http.CanonicalHeaderKey` function call which is not needed for `Header.Get`