### PR TITLE
Add WebsocketProxy.Director optional function to forward additional headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: go
-go: 1.2
+go: 1.8


### PR DESCRIPTION
Useful in situations where a WebSocket HTTP server that is being proxied to
requires custom headers, and also should fix issues like https://github.com/koding/websocketproxy/issues/9