### PR TITLE
Don't forward `CloseAbnormalClosure`(`1006`) and `CloseTLSHandshake`(`1015`)  as close frames

### DIFF
--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -181,11 +181,18 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				m := websocket.FormatCloseMessage(websocket.CloseNormalClosure, fmt.Sprintf("%v", err))
 				if e, ok := err.(*websocket.CloseError); ok {
 					if e.Code != websocket.CloseNoStatusReceived {
-						m = websocket.FormatCloseMessage(e.Code, e.Text)
+						m = nil
+						// Following codes are not valid on the wire so just close the
+						// underlying TCP connection without sending a close frame.
+						if e.Code != websocket.CloseAbnormalClosure && e.Code != websocket.CloseTLSHandshake {
+							m = websocket.FormatCloseMessage(e.Code, e.Text)
+						}
 					}
 				}
 				errc <- err
-				dst.WriteMessage(websocket.CloseMessage, m)
+				if m != nil {
+					dst.WriteMessage(websocket.CloseMessage, m)
+				}
 				break
 			}
 			err = dst.WriteMessage(msgType, msg)


### PR DESCRIPTION
This PR fixes the issue where `CloseAbnormalClosure`(`1006`) and `CloseTLSHandshake`(`1015`) are incorrectly forwarded as close frames, as they are `reserved`.

Changes are made in correspondence to https://github.com/vulcand/oxy/blob/master/forward/fwd.go#L402-L418.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent