### PR TITLE
Preserve host header

### DIFF
--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -97,8 +97,8 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, cookie := range req.Header[http.CanonicalHeaderKey("Cookie")] {
 		requestHeader.Add("Cookie", cookie)
 	}
-	if host := req.Host; host != "" {
-		requestHeader.Set("Host", host)
+	if req.Host != "" {
+		requestHeader.Set("Host", req.Host)
 	}
 
 	// Pass X-Forwarded-For headers too, code below is a part of

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -97,6 +97,9 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, cookie := range req.Header[http.CanonicalHeaderKey("Cookie")] {
 		requestHeader.Add("Cookie", cookie)
 	}
+	if host := req.Host; host != "" {
+		requestHeader.Set("Host", host)
+	}
 
 	// Pass X-Forwarded-For headers too, code below is a part of
 	// httputil.ReverseProxy. See http://en.wikipedia.org/wiki/X-Forwarded-For

--- a/websocketproxy_test.go
+++ b/websocketproxy_test.go
@@ -45,6 +45,12 @@ func TestProxy(t *testing.T) {
 	go func() {
 		mux2 := http.NewServeMux()
 		mux2.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			// Don't upgrade if original host header isnt preserved
+			if r.Host !=  "127.0.0.1:7777" {
+				log.Printf("Host header set incorrectly.  Expecting 127.0.0.1:7777 got %s", r.Host)
+				return
+			}
+
 			conn, err := upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				log.Println(err)

--- a/websocketproxy_test.go
+++ b/websocketproxy_test.go
@@ -45,7 +45,7 @@ func TestProxy(t *testing.T) {
 	go func() {
 		mux2 := http.NewServeMux()
 		mux2.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			// Don't upgrade if original host header isnt preserved
+			// Don't upgrade if original host header isn't preserved
 			if r.Host !=  "127.0.0.1:7777" {
 				log.Printf("Host header set incorrectly.  Expecting 127.0.0.1:7777 got %s", r.Host)
 				return


### PR DESCRIPTION
Some web applications use the original host header sent by the browser to do things that would prevent them from working properly if the original host header isn't preserved.  

For example:
- CRSF header checks
- Virtual hosting
- Looking up the name of cookies (weird I know, but the application I was proxying did this) 

This PR preserves the original host header and adds a host header check in the test to simulate an application that does this.