### PR TITLE
Support for forwarding end-to-end headers

### DIFF
--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -99,6 +99,14 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	requestHeader.Del("Sec-Websocket-Version")
 	requestHeader.Del("Upgrade")
 
+	// Remove all hop-by-hop headers
+	requestHeader.Del("Keep-Alive")
+	requestHeader.Del("Transfer-Encoding")
+	requestHeader.Del("TE")
+	requestHeader.Del("Trailer")
+	requestHeader.Del("Proxy-Authorization")
+	requestHeader.Del("Proxy-Authenticate")
+
 	if origin := req.Header.Get("Origin"); origin != "" {
 		requestHeader.Add("Origin", origin)
 	}

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -92,7 +92,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// gorilla/websocket automatically adds these headers back when Dial() is called, but it never
 	// uses Set(), rather it sets these headers using normal assignment might can so lead to
 	// duplicate headers. Hence, we can remove them. (If this problem gets fixed in gorilla/websocket,
-	// these 4 lines become redundant, but will not break the current implementation)
+	// these 5 lines become redundant, but will not break the current implementation)
 	requestHeader.Del("Connection")
 	requestHeader.Del("Sec-Websocket-Extensions")
 	requestHeader.Del("Sec-Websocket-Key")

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -89,8 +89,10 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// the final destinations.
 	requestHeader := req.Header.Clone()
 
-	// gorilla/websocket adds these headers back, but it never .Set() them, so leaving these
-	// headers leads to duplicates
+	// gorilla/websocket automatically adds these headers back when Dial() is called, but it never
+	// uses Set(), rather it sets these headers using normal assignment might can so lead to
+	// duplicate headers. Hence, we can remove them. (If this problem gets fixed in gorilla/websocket,
+	// these 4 lines become redundant, but will not break the current implementation)
 	requestHeader.Del("Connection")
 	requestHeader.Del("Sec-Websocket-Extensions")
 	requestHeader.Del("Sec-Websocket-Key")

--- a/websocketproxy.go
+++ b/websocketproxy.go
@@ -87,7 +87,16 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Pass headers from the incoming request to the dialer to forward them to
 	// the final destinations.
-	requestHeader := http.Header{}
+	requestHeader := req.Header.Clone()
+
+	// gorilla/websocket adds these headers back, but it never .Set() them, so leaving these
+	// headers leads to duplicates
+	requestHeader.Del("Connection")
+	requestHeader.Del("Sec-Websocket-Extensions")
+	requestHeader.Del("Sec-Websocket-Key")
+	requestHeader.Del("Sec-Websocket-Version")
+	requestHeader.Del("Upgrade")
+
 	if origin := req.Header.Get("Origin"); origin != "" {
 		requestHeader.Add("Origin", origin)
 	}


### PR DESCRIPTION
Adds support for all end-to-end headers to be passed through the proxy, which can help in implementations where authorization or custom headers are used.